### PR TITLE
fix: DIA-1740: 'int' not iterable when Rating GT empty

### DIFF
--- a/evalme/classification.py
+++ b/evalme/classification.py
@@ -82,6 +82,8 @@ class ClassificationEvalItem(EvalItem):
             # mark labels in 1st annotation with 0 score
             for x in self.get_values_iter():
                 labels = x[self._shape_key]
+                if not isinstance(labels, list):
+                    labels = [labels]
                 for label in labels:
                     total_weight[label] = 0
         if per_label:

--- a/evalme/classification.py
+++ b/evalme/classification.py
@@ -98,7 +98,7 @@ class ChoicesEvalItem(ClassificationEvalItem):
 
 
 class PairwiseEvalItem(ClassificationEvalItem):
-    SHAPE_KEY = 'pairwise'
+    SHAPE_KEY = 'selected'
 
 
 def _as_choices(item, shape_key, **kwargs):


### PR DESCRIPTION
Most control tags' labels are stored in a list, for some like Number and Rating it is just a single int. We were not handling the case where the annotation to compare against is emtpy, for a Rating / Number tag

Fixed DIA-1741 here as well. We were never calculating pairwise comparisons correctly. We were catching an exception in the case both annotation and pred have non-empty pairwise selection, but issue manifested when  GT was empty
We were using the wrong key all along